### PR TITLE
Added metadata from nova for ironic nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+
+# ENV files with potential secrets for testing purposes
+*.env

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # ipmi_sd
 
-Custom Prometheus service discovery to get ipmi address of ironic nodes.
+A Prometheus service discovery to get the ipmi address of Openstack ironic nodes and enrich
+them with nova metadata.
 
-Discovery service gets ipmi addresses of all nodes via ironic and writes those targets into a configmap every x seconds.
+The discovery gets the ipmi addresses of all nodes via ironic and some metadata
+from nova and writes these into a json in a Kubernetes configmap in a periodic interval.
+
+The configmap can then be consumed by the Prometheus `file_sd` discovery
+mechanism.

--- a/cmd/discovery/ipmi_discovery.go
+++ b/cmd/discovery/ipmi_discovery.go
@@ -73,6 +73,7 @@ func main() {
 	}
 
 	ic, err := clients.NewIronicClient(provider)
+	nc, err := openstack.NewComputeV2(provider, gophercloud.EndpointOpts{})
 
 	ctx := context.Background()
 
@@ -91,7 +92,7 @@ func main() {
 		level.Error(log.With(logger, "component", "ipmi_discovery")).Log("err", "no configmap name given")
 	}
 
-	disc, err := discovery.NewDiscovery(ic, *refreshInterval, logger)
+	disc, err := discovery.NewDiscovery(nc, ic, *refreshInterval, logger)
 	if err != nil {
 		level.Error(log.With(logger, "component", "ipmi_discovery")).Log("err", err)
 	}

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -6,12 +6,15 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/discovery/targetgroup"
 	"github.com/sapcc/ipmi_sd/pkg/clients"
 )
 
 type discovery struct {
+	novaClient      *gophercloud.ServiceClient
 	ironicClient    *clients.IronicClient
 	refreshInterval int
 	tagSeparator    string
@@ -19,20 +22,22 @@ type discovery struct {
 }
 
 func (d *discovery) parseServiceNodes() ([]*targetgroup.Group, error) {
-	nodes, err := d.ironicClient.GetNodes()
+	ironicNodes, err := d.ironicClient.GetNodes()
 	if err != nil {
 		level.Error(log.With(d.logger, "component", "ironicClient")).Log("err", err)
 		return nil, err
 	}
 
-	if len(nodes) == 0 {
+	if len(ironicNodes) == 0 {
 		err := level.Error(log.With(d.logger, "component", "discovery")).Log("err", "no ironic nodes found")
 		return nil, err
 	}
 
 	var tgroups []*targetgroup.Group
 
-	for _, node := range nodes {
+	for _, node := range ironicNodes {
+		var instance *servers.Server
+
 		tgroup := targetgroup.Group{
 			Source:  node.DriverInfo.IpmiAddress,
 			Labels:  make(model.LabelSet),
@@ -41,11 +46,24 @@ func (d *discovery) parseServiceNodes() ([]*targetgroup.Group, error) {
 
 		target := model.LabelSet{model.AddressLabel: model.LabelValue(node.DriverInfo.IpmiAddress)}
 		labels := model.LabelSet{
-			model.LabelName("job"):          "baremetal/ironic",
 			model.LabelName("serial"):       model.LabelValue(node.Properties.SerialNumber),
 			model.LabelName("manufacturer"): model.LabelValue(node.Properties.Manufacturer),
 			model.LabelName("model"):        model.LabelValue(node.Properties.Model),
 		}
+
+		// Check if node is used by a tenant and add instance metadata
+		if node.InstanceUuid != "" {
+			instance, err = servers.Get(d.novaClient, node.InstanceUuid).Extract()
+			if err != nil {
+				d.logger.Log(err.Error())
+				return nil, err
+			}
+			labels[model.LabelName("server_id")] = model.LabelValue(node.InstanceUuid)
+			labels[model.LabelName("server_name")] = model.LabelValue(instance.Name)
+			labels[model.LabelName("project_id")] = model.LabelValue(instance.TenantID)
+			labels[model.LabelName("user_id")] = model.LabelValue(instance.UserID)
+		}
+
 		tgroup.Labels = labels
 		tgroup.Targets = append(tgroup.Targets, target)
 		tgroups = append(tgroups, &tgroup)
@@ -54,9 +72,10 @@ func (d *discovery) parseServiceNodes() ([]*targetgroup.Group, error) {
 	return tgroups, nil
 }
 
-func NewDiscovery(client *clients.IronicClient, refreshInterval int, logger log.Logger) (*discovery, error) {
+func NewDiscovery(novaClient *gophercloud.ServiceClient, ironicClient *clients.IronicClient, refreshInterval int, logger log.Logger) (*discovery, error) {
 	cd := &discovery{
-		ironicClient:    client,
+		novaClient:      novaClient,
+		ironicClient:    ironicClient,
 		refreshInterval: refreshInterval,
 		logger:          logger,
 	}

--- a/pkg/clients/ironic.go
+++ b/pkg/clients/ironic.go
@@ -55,6 +55,7 @@ func NewIronicClient(provider *gophercloud.ProviderClient) (*IronicClient, error
 type ironicNode struct {
 	ID                   string  `json:"uuid"`
 	Name                 string  `json:"name"`
+	InstanceUuid         string  `json:"instance_uuid"`
 	ProvisionState       string  `json:"provision_state"`
 	TargetProvisionState *string `json:"target_provision_state"`
 	Properties           struct {


### PR DESCRIPTION
This is obviously useful to associate metrics with projects and users.
The nova names are a convenience and mostly for faster triage by users.

# Effect on cardinality

There is a certain risk for a bit more cardinality when users change
their baremetal machines more often. Considering that these users
literally book full baremetal machines the costs for additional
Prometheus compute and long term storage is economically negliable.

# Changed label names

Consulting with @jobrs brought up inconsistencies in our naming schemes.
We hope the names are now better than before.
We dropped the label job as these should never be set by the source of
the metric and definitely not from a service discovery because we don’t know
for what the discovery will be used in the future.